### PR TITLE
Update 'echo' to 'echo -e' in psw/ae/buildenv.mk

### DIFF
--- a/psw/ae/buildenv.mk
+++ b/psw/ae/buildenv.mk
@@ -92,4 +92,4 @@ vpath %.cpp $(COMMON_DIR)/src:\
 
 .PHONY : version
 version:
-	echo "#include \"se_version.h\"\nchar version[] = \"\$$SGXVer: LinuxOpenSource\" STRFILEVER \"\$$\";" > $(LINUX_PSW_DIR)/ae/common/version.cpp
+	echo -e "#include \"se_version.h\"\nchar version[] = \"\$$SGXVer: LinuxOpenSource\" STRFILEVER \"\$$\";" > $(LINUX_PSW_DIR)/ae/common/version.cpp


### PR DESCRIPTION
Without the '-e' echo fails to escape the '\n' on bash version 4.3.11