### PR TITLE
Set misc_attr for failing _create_enclave flows

### DIFF
--- a/psw/urts/linux/urts.cpp
+++ b/psw/urts/linux/urts.cpp
@@ -58,6 +58,14 @@ extern "C" sgx_status_t sgx_create_enclave(const char *file_name, const int debu
     file.name_len = (uint32_t)strlen(resolved_path);
 
     ret = _create_enclave(!!debug, fd, file, NULL, launch_token, launch_token_updated, enclave_id, misc_attr);
+    if(SGX_SUCCESS != ret && misc_attr)
+    {
+        sgx_misc_attribute_t plat_cap;
+        memset(&plat_cap, 0, sizeof(plat_cap));
+        get_enclave_creator()->get_plat_cap(&plat_cap);
+        memcpy_s(misc_attr, sizeof(sgx_misc_attribute_t), &plat_cap, sizeof(sgx_misc_attribute_t));
+    }
+
     close(fd);
 
     return ret;

--- a/psw/urts/loader.cpp
+++ b/psw/urts/loader.cpp
@@ -641,7 +641,7 @@ int CLoader::load_enclave(SGXLaunchToken *lc, int debug, const metadata_t *metad
     }
 
     ret = build_image(lc, &sgx_misc_attr.secs_attr, prd_css_file, &sgx_misc_attr);
-    //return platform capability if fail. Otherwise, return secs.attr.
+    //Update misc_attr with secs.attr upon success.
     if(SGX_SUCCESS == ret)
     {
         if(misc_attr)
@@ -649,16 +649,6 @@ int CLoader::load_enclave(SGXLaunchToken *lc, int debug, const metadata_t *metad
             memcpy_s(misc_attr, sizeof(sgx_misc_attribute_t), &sgx_misc_attr, sizeof(sgx_misc_attribute_t));
             //When run here EINIT success, so SGX_FLAGS_INITTED should be set by ucode. uRTS align it with EINIT instruction.
             misc_attr->secs_attr.flags |= SGX_FLAGS_INITTED;
-        }
-    }
-    else
-    {
-        if(misc_attr)
-        {
-            sgx_misc_attribute_t plat_cap;
-            memset(&plat_cap, 0, sizeof(plat_cap));
-            get_enclave_creator()->get_plat_cap(&plat_cap);
-            memcpy_s(misc_attr, sizeof(sgx_misc_attribute_t), &plat_cap, sizeof(sgx_misc_attribute_t));
         }
     }
 


### PR DESCRIPTION
Set misc_attr in the top level sgx_create_enclave if _create_enclave
fails.  This provides the user with the platform's capabilities when
sgx_create_enclave fails for any reason other than a parameter error.

Previously the misc_attr was only set upon failure if build_image
failed, which was not helpful when sgx_create_enclave failed due to
an attribute error, e.g. misc_select, as the flow aborted before it
reached build_image.

Signed-off-by: Sean Christopherson <sean.j.christopherson@intel.com>