### PR TITLE
Pass secs.attr.xfrm to EnclaveCreator::initialize

### DIFF
--- a/common/inc/internal/enclave_creator.h
+++ b/common/inc/internal/enclave_creator.h
@@ -66,7 +66,7 @@ public:
     virtual int add_enclave_page(sgx_enclave_id_t enclave_id, void *source, uint64_t offset, const sec_info_t &sinfo, uint32_t attr) = 0;
     virtual int init_enclave(sgx_enclave_id_t enclave_id, enclave_css_t *enclave_css, SGXLaunchToken *lc, le_prd_css_file_t *prd_css_file = NULL) = 0;
     virtual int destroy_enclave(sgx_enclave_id_t enclave_id) = 0;
-    virtual int initialize(sgx_enclave_id_t enclave_id) = 0;
+    virtual int initialize(sgx_enclave_id_t enclave_id, uint64_t xfrm) = 0;
     virtual bool use_se_hw() const = 0;
 
     virtual int get_misc_attr(sgx_misc_attribute_t *sgx_misc_attr, metadata_t *metadata, SGXLaunchToken * const lc, uint32_t flag) = 0;

--- a/common/inc/internal/rts.h
+++ b/common/inc/internal/rts.h
@@ -60,6 +60,7 @@ typedef struct _ocall_context_t
 typedef enum
 {
     SDK_VERSION_1_5,
+    SDK_VERSION_1_6,
     SDK_VERSION_2_0
 } sdk_version_t;
 
@@ -67,6 +68,7 @@ typedef struct _cpu_feature_sdk_version
 {
     uint64_t cpu_features;
     sdk_version_t version;
+    uint64_t xfrm;
 }cpu_sdk_info_t;
 
 #define     OCALL_FLAG        0x4F434944

--- a/common/inc/internal/xsave.h
+++ b/common/inc/internal/xsave.h
@@ -53,7 +53,7 @@ void save_and_clean_xfeature_regs(uint8_t *buffer);
 void restore_xfeature_regs(const uint8_t *buffer);
 
 /* trts_xsave.cpp */
-uint64_t get_xfeature_state();
+void init_xfeature_state(uint64_t xfrm);
 
 
 #ifdef __cplusplus

--- a/psw/urts/enclave_creator_hw.h
+++ b/psw/urts/enclave_creator_hw.h
@@ -53,7 +53,7 @@ public:
     int add_enclave_page(sgx_enclave_id_t enclave_id, void *source, uint64_t offset, const sec_info_t &sinfo, uint32_t attr);
     int init_enclave(sgx_enclave_id_t enclave_id, enclave_css_t *enclave_css, SGXLaunchToken *lc, le_prd_css_file_t *prd_css_file);
     int destroy_enclave(sgx_enclave_id_t enclave_id);
-    int initialize(sgx_enclave_id_t enclave_id);
+    int initialize(sgx_enclave_id_t enclave_id, uint64_t xfrm);
     bool use_se_hw() const;
     int get_misc_attr(sgx_misc_attribute_t *sgx_misc_attr, metadata_t *metadata, SGXLaunchToken * const lc, uint32_t flag);
     bool get_plat_cap(sgx_misc_attribute_t *se_attr);

--- a/psw/urts/enclave_creator_hw_com.cpp
+++ b/psw/urts/enclave_creator_hw_com.cpp
@@ -45,7 +45,7 @@ bool EnclaveCreatorHW::use_se_hw() const
     return true;
 }
 
-int EnclaveCreatorHW::initialize(sgx_enclave_id_t enclave_id)
+int EnclaveCreatorHW::initialize(sgx_enclave_id_t enclave_id, uint64_t xfrm)
 {
     cpu_sdk_info_t info;
 
@@ -57,7 +57,9 @@ int EnclaveCreatorHW::initialize(sgx_enclave_id_t enclave_id)
     //Since CPUID instruction is NOT supported within enclave, we enumerate the cpu features here and send to tRTS.
     info.cpu_features = 0;
     get_cpu_features(&info.cpu_features);
-    info.version = SDK_VERSION_1_5;
+    //XCR0 will be loaded from SECS.ATTRIBUTES.XFRM, send XFRM to tRTS so that it is aware of the effective XCR0.
+    info.xfrm = xfrm;
+    info.version = SDK_VERSION_1_6;
 
     int status = enclave->ecall(ECMD_INIT_ENCLAVE, NULL, reinterpret_cast<void *>(&info));
     //free the tcs used by initialization;

--- a/psw/urts/urts_com.h
+++ b/psw/urts/urts_com.h
@@ -244,7 +244,7 @@ static int __create_enclave(BinParser &parser, uint8_t* base_addr, const metadat
 
 
     //call trts to do some intialization
-    if(SGX_SUCCESS != (ret = get_enclave_creator()->initialize(loader.get_enclave_id())))
+    if(SGX_SUCCESS != (ret = get_enclave_creator()->initialize(loader.get_enclave_id(), loader.get_secs().attributes.xfrm)))
     {
         sgx_status_t status = SGX_SUCCESS;
         CEnclavePool::instance()->remove_enclave(loader.get_enclave_id(), status);

--- a/sdk/sign_tool/SignTool/enclave_creator_sign.cpp
+++ b/sdk/sign_tool/SignTool/enclave_creator_sign.cpp
@@ -249,9 +249,9 @@ bool EnclaveCreatorST::get_plat_cap(sgx_misc_attribute_t *se_attr)
     return false;
 }
 
-int EnclaveCreatorST::initialize(sgx_enclave_id_t enclave_id)
+int EnclaveCreatorST::initialize(sgx_enclave_id_t enclave_id, uint64_t xfrm)
 {
-    UNUSED(enclave_id);
+    UNUSED(enclave_id), UNUSED(xfrm);
     return SGX_SUCCESS;
 }
 

--- a/sdk/sign_tool/SignTool/enclave_creator_sign.h
+++ b/sdk/sign_tool/SignTool/enclave_creator_sign.h
@@ -50,7 +50,7 @@ public:
     int get_misc_attr(sgx_misc_attribute_t *sgx_misc_attr, metadata_t *metadata, SGXLaunchToken * const lc, uint32_t flag);
     bool get_plat_cap(sgx_misc_attribute_t *se_attr);
     int destroy_enclave(sgx_enclave_id_t enclave_id);
-    int initialize(sgx_enclave_id_t enclave_id);
+    int initialize(sgx_enclave_id_t enclave_id, uint64_t xfrm);
     bool use_se_hw() const;
 
     int get_enclave_info(uint8_t *hash, int size);

--- a/sdk/simulation/urtssim/enclave_creator_sim.cpp
+++ b/sdk/simulation/urtssim/enclave_creator_sim.cpp
@@ -177,7 +177,7 @@ int EnclaveCreatorSim::destroy_enclave(sgx_enclave_id_t enclave_id)
     return ::destroy_enclave(enclave_id);
 }
 
-int EnclaveCreatorSim::initialize(sgx_enclave_id_t enclave_id)
+int EnclaveCreatorSim::initialize(sgx_enclave_id_t enclave_id, uint64_t xfrm)
 {
     CEnclave *enclave = CEnclavePool::instance()->get_enclave(enclave_id);
 
@@ -216,7 +216,9 @@ int EnclaveCreatorSim::initialize(sgx_enclave_id_t enclave_id)
     cpu_sdk_info_t info;
     info.cpu_features = 0;
     get_cpu_features(&info.cpu_features);
-    info.version = SDK_VERSION_1_5;
+    //XCR0 will be loaded from SECS.ATTRIBUTES.XFRM, send XFRM to tRTS so that it is aware of the effective XCR0.
+    info.xfrm = xfrm;
+    info.version = SDK_VERSION_1_6;
     status = enclave->ecall(ECMD_INIT_ENCLAVE, NULL, reinterpret_cast<void *>(&info));
     //free the tcs used by initialization;
     enclave->get_thread_pool()->reset();

--- a/sdk/simulation/urtssim/enclave_creator_sim.h
+++ b/sdk/simulation/urtssim/enclave_creator_sim.h
@@ -46,7 +46,7 @@ public:
     virtual int destroy_enclave(sgx_enclave_id_t enclave_id);
     int get_misc_attr(sgx_misc_attribute_t *sgx_misc_attr, metadata_t *metadata, SGXLaunchToken * const lc, uint32_t flag);
     bool get_plat_cap(sgx_misc_attribute_t *se_attr);
-    int initialize(sgx_enclave_id_t enclave_id);
+    int initialize(sgx_enclave_id_t enclave_id, uint64_t xfrm);
     bool use_se_hw() const;
 };
 

--- a/sdk/trts/init_enclave.cpp
+++ b/sdk/trts/init_enclave.cpp
@@ -94,14 +94,14 @@ extern "C" int init_enclave(void *enclave_base, void *ms)
     const sdk_version_t sdk_version = info->version;
     const uint64_t cpu_features = info->cpu_features;
     
-    if (sdk_version != SDK_VERSION_1_5)
+    if (sdk_version != SDK_VERSION_1_6)
         return -1;
 
     // xsave
-    uint64_t xfrm = get_xfeature_state();
+    init_xfeature_state(info->xfrm);
 
     // optimized libs
-    if(0 != init_optimized_libs(cpu_features, xfrm))
+    if(0 != init_optimized_libs(cpu_features, info->xfrm))
     {
         CLEAN_XFEATURE_REGS
         return -1;

--- a/sdk/trts/trts_xsave.cpp
+++ b/sdk/trts/trts_xsave.cpp
@@ -34,6 +34,7 @@
 #include "xsave.h"
 #include "trts_inst.h"
 #include "util.h"
+#include "se_cpu_feature_defs.h"
 
 // 'SYNTHETIC_STATE' buffer size is (512 + 64 + 256) bytes
 //   512 for fxsave buffer,
@@ -51,27 +52,15 @@ SYNTHETIC_STATE[SYNTHETIC_STATE_SIZE/sizeof(uint16_t)] = {
 
 static int g_xsave_enabled;             // flag to indicate whether xsave is enabled or not
 
-// EENTER will set xcr0 with secs.attr.xfrm, 
-// So use the xfeature mask from report instead of calling xgetbv
-uint64_t get_xfeature_state()
+// init_xfeature_state()
+//      init g_xsave_enabled based on secs.attr.xfrm.  EENTER will set xcr0 with secs.attr.xfrm,
+// Parameters:
+//      xfrm - secs.attr.xfrm value
+// Return Value:
+//      none
+void init_xfeature_state(uint64_t xfrm)
 {
-    // target_info and report_data are useless
-    // we only need to make sure their alignment and within enclave
-    // so set the pointers to SYNTHETIC_STATE
-    sgx_target_info_t *target_info = (sgx_target_info_t *)SYNTHETIC_STATE;
-    sgx_report_data_t *report_data = (sgx_report_data_t *)SYNTHETIC_STATE;
-    uint8_t buffer[sizeof(sgx_report_t) + REPORT_ALIGN_SIZE -1] = {0};
-    sgx_report_t *report = (sgx_report_t *)ROUND_TO((size_t)buffer, REPORT_ALIGN_SIZE);
-
-    do_ereport(target_info, report_data, report);
-
-    g_xsave_enabled = (report->body.attributes.xfrm == SGX_XFRM_LEGACY) ? 0 : 1;
-    uint64_t xfrm = report->body.attributes.xfrm;
-
-    // no secrets in target_info, report_data, and report. no need to clear them before return
-    // tlibc functions cannot be used before calling init_optimized_libs().
-
-    return xfrm;
+    g_xsave_enabled = XFEATURE_ENABLED_AVX(xfrm) ? 1 : 0;
 }
 
 // save_and_clean_xfeature_regs()


### PR DESCRIPTION
Pass the SECS's XFRM to initialize to avoid having to do EREPORT to
retrieve the effective XCR0 value for the enclave.  Bump the version
to SDK_VERSION_1_6 to note the change in the info struct.

Fixes #12.

Signed-off-by: Sean Christopherson <sean.j.christopherson@intel.com>

**WARNING:**  I have not tested this exact patch as I cannot rebuild the prebuilt enclaves, i.e. AESM won't run due to the SDK version difference.  For testing I left the version at SDK_VERSION_1_5. 