### PR TITLE
Skip EEXTEND for .bss sections

### DIFF
--- a/psw/urts/loader.cpp
+++ b/psw/urts/loader.cpp
@@ -171,7 +171,7 @@ int CLoader::build_mem_region(const section_info_t * const sec_info)
     {
         size_t size = (size_t)(ROUND_TO_PAGE(sec_info->virtual_size) - ROUND_TO_PAGE(sec_info->raw_data_size));
         sinfo.flags = sec_info->flag;
-        if(SGX_SUCCESS != (ret = build_pages(rva, size, 0, sinfo, ADD_EXTEND_PAGE)))
+        if(SGX_SUCCESS != (ret = build_pages(rva, size, 0, sinfo, ADD_PAGE_ONLY)))
             return ret;
     }
 


### PR DESCRIPTION
.bss sections reserve space for uninitialized data.  Applications cannot
rely on uninitialized data to hold a specific value, thus measuring .bss
sections provides no value or additional security.

Signed-off-by: Sean Christopherson <sean.j.christopherson@intel.com>

This change significantly speeds up `sgx_create_enclave` for applications with large .bss sections (large buffers, custom memory allocation, etc...), e.g. create time with a 12mb .bss is ~20ms versus ~100ms without the change.

**WARNING:** This change breaks backwards compatibility, i.e. it requires prebuilt enclaves to be rebuilt.  A version which allows applications to opt-in to the behavior can be found [here](https://github.com/sean-jc/linux-sgx/tree/bss_opt_in_no_eextend), which allows utilizing this behavior while still being able to load existing prebuilt enclaves.