### PR TITLE
Update .gitignore files to ignore known artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 *.so
 *.so.*
 
+#map files
+*.map
+
 #generated proxy
 *_u.c
 *_u.h
@@ -15,5 +18,27 @@
 *_t.h
 
 #output files
+output/
 /build/
+/sdk/edger8r/linux/_build/
+
+#installer files
 /linux/installer/bin/*.bin
+/linux/installer/common/sdk/pkgconfig/x86/
+/linux/installer/common/sdk/pkgconfig/x64/
+/linux/installer/common/psw/gen_source.py
+/linux/installer/common/sdk/gen_source.py
+
+#AESM generated files
+/psw/ae/aesm_service/aesm_service
+/psw/ae/aesm_service/data/
+/psw/ae/aesm_service/source/protobuf/messages.pb.cc
+/psw/ae/aesm_service/source/protobuf/messages.pb.h
+/psw/ae/aesm_service/source/protobuf/messages.proto
+/psw/ae/common/proto/messages.pb.cc
+/psw/ae/common/proto/messages.pb.h
+/psw/ae/common/version.cpp
+
+#misc executables
+/sdk/sign_tool/SignTool/sgx_sign
+/sdk/simulation/SEConfigureCPUSVN/linux/sgx_config_cpusvn

--- a/external/rdrand/.gitignore
+++ b/external/rdrand/.gitignore
@@ -1,0 +1,5 @@
+src/test
+src/Makefile
+src/config.h
+src/config.log
+src/config.status

--- a/sdk/cpprt/linux/libunwind/.gitignore
+++ b/sdk/cpprt/linux/libunwind/.gitignore
@@ -1,0 +1,30 @@
+libtool
+
+#libtool static library
+*.la
+
+#libtool shared object
+*.lo
+
+*.dirstamp
+.deps/
+.libs/
+
+INSTALL
+Makefile
+Makefile.in
+aclocal.m4
+autom4te.cache/
+config.log
+config.status
+config/
+configure
+include/config.h
+include/config.h.in
+include/libunwind-common.h
+include/libunwind.h
+include/pthread_compat.h
+include/stamp-h1
+include/tdep/libunwind_i.h
+src/Makefile
+src/Makefile.in


### PR DESCRIPTION
Ignore output and generated files from libunwind, rdrand, installer and
AESM.  Ignore all known executables that are created, e.g. sgx_sign.

Signed-off-by: Sean Christopherson sean.j.christopherson@intel.com

I split out libunwind and rdrand into separate files to keep the top-level .gitignore cleaner, let me know if you would prefer to have everything in a single file.
