### PR TITLE
Clean up build_sections and build_mem_region code

### DIFF
--- a/common/inc/internal/util.h
+++ b/common/inc/internal/util.h
@@ -58,6 +58,7 @@
 #define	ROUND_TO(x, align)  (((x) + ((align)-1)) & ~((align)-1))
 #define	ROUND_TO_PAGE(x)    ROUND_TO(x, SE_PAGE_SIZE)
 #define	TRIM_TO_PAGE(x) ((x) & ~(SE_PAGE_SIZE-1))
+#define PAGE_OFFSET(x) ((x) & (SE_PAGE_SIZE -1))
 #ifdef __cplusplus
 #define PAGE_ALIGN(t, x)	reinterpret_cast<t*>((reinterpret_cast<size_t>(x)+(SE_PAGE_SIZE-1)) & (~(SE_PAGE_SIZE-1)))
 #else

--- a/psw/urts/loader.h
+++ b/psw/urts/loader.h
@@ -68,12 +68,14 @@ public:
     int set_memory_protection();
 
 private:
-    int build_mem_region(const section_info_t * const sec_info);
+    int build_mem_region(const section_info_t &sec_info);
     int build_image(SGXLaunchToken * const lc, sgx_attributes_t * const secs_attr, le_prd_css_file_t *prd_css_file, sgx_misc_attribute_t * const misc_attr);
     int build_secs(sgx_attributes_t * const secs_attr, sgx_misc_attribute_t * const misc_attr);
     int build_context(const uint64_t start_rva, layout_entry_t *layout);
     int build_contexts(layout_t *layout_start, layout_t *layout_end, uint64_t delta);
-    int build_pages(const uint64_t start_rva, const uint64_t size, void *source, const sec_info_t &sinfo, const uint32_t attr);
+    int build_partial_page(const uint64_t rva, const uint64_t size, const void *source, const sec_info_t &sinfo, const uint32_t attr);
+    int build_pages(const uint64_t start_rva, const uint64_t size, const void *source, const sec_info_t &sinfo, const uint32_t attr);
+    bool is_relocation_page(const uint64_t rva, vector<uint8_t> *bitmap);
 
     bool is_ae(const enclave_css_t *enclave_css);
     bool is_metadata_buffer(uint32_t offset, uint32_t size);

--- a/psw/urts/section_info.h
+++ b/psw/urts/section_info.h
@@ -40,7 +40,7 @@ using namespace std;
 
 typedef struct _section_info_t
 {
-    uint8_t *raw_data;          //The file pointer to the first page of the section.
+    const uint8_t *raw_data;    //The file pointer to the first page of the section.
     uint64_t raw_data_size;     //The size of the section or the size of the initialized section on disk.
     uint64_t rva;               //The address of the first byte of the section relative to the image base when section is loaded into memory.
     uint64_t virtual_size;      //The total size of the section when loaded into memory.


### PR DESCRIPTION
Modify build_mem_region to support an unaligned starting address.  This
makes it symmetrical with regard to starting and ending partial pages;
previously, build_mem_region only support partial pages at the end of a
section (caller was responsible for handling the first page).  Remove
the edge case handling of the first page from build_sections now that
build_mem_region does not have alignment restrictions.

Change the section_info_t parameter in build_mem_region to be a const
reference to eliminate any need to check for a null pointer.

Make the raw_data pointer in section_info_t const, as the source file's
data should never be modified.  This is currently cast away via GET_PTR
in build_pages when calling into add_enclave_page; the add_enclave_page
flow can be modified by a future commit to retain the const modifier.

Add two utilities, is_relocation_page and build_partial_page, to reduce
copy-paste code.

Add PAGE_OFFSET macro to calculate the offset within a page.

Assert on address/size alignment in build_pages and build_context to
document expected alignment and catch any related code bugs.

Signed-off-by: Sean Christopherson <sean.j.christopherson@intel.com>