### PR TITLE
GCC 6 compatibility

### DIFF
--- a/buildenv.mk
+++ b/buildenv.mk
@@ -94,6 +94,9 @@ CXXFLAGS += -Wnon-virtual-dtor
 # for static_assert()
 CXXFLAGS += -std=c++0x
 
+# Disable cxx11 abi
+CXXFLAGS += -D_GLIBCXX_USE_CXX11_ABI=0
+
 .DEFAULT_GOAL := all
 # this turns off the RCS / SCCS implicit rules of GNU Make
 % : RCS/%,v

--- a/psw/ae/aesm_service/Makefile
+++ b/psw/ae/aesm_service/Makefile
@@ -82,6 +82,9 @@ INCLUDE += -I$(SGX_IPP_INC) \
 
 EDGER8R  := $(LINUX_SDK_DIR)/edger8r/linux/_build/Edger8r.native
 
+# Disable cxx11 abi
+CXXFLAGS += -D_GLIBCXX_USE_CXX11_ABI=0
+
 ifdef PROFILE
         CXXFLAGS += -D_PROFILE_
         CFLAGS += -D_PROFILE_

--- a/psw/uae_service/linux/Makefile
+++ b/psw/uae_service/linux/Makefile
@@ -69,6 +69,8 @@ ifeq ($(ARCH), x86)
 else
 	PROTPBUF_CXXFLAGS += -m64
 endif
+PROTPBUF_CXXFLAGS += -D_GLIBCXX_USE_CXX11_ABI=0
+
 
 EXTERNAL_LIB += -lprotobuf 
  


### PR DESCRIPTION
In GCC 6 `--std=c++11` became the default, which changes the ABI. This breaks dynamic linkage with things like libprotobuf.so.8, resulting in errors like
```
messages.pb.o:(.data.rel.ro._ZTVN4aesm7message23Request_GetQuoteRequestE[_ZTVN4aesm7message23Request_GetQuoteRequestE]+0x20): undefined reference to `google::protobuf::Message::GetTypeName[abi:cxx11]() const'
(...)
% nm -D /usr/lib/libprotobuf.so.8 | grep GetTypeName | c++filt
00000000000b1b80 T google::protobuf::Message::GetTypeName() const
```

 This PR adds a flag to the build that disables the new ABI until deps are bumped to past-c++11.