### PR TITLE
Change mallinfo field type to int as per system malloc.h

### DIFF
--- a/sdk/tlibc/stdlib/malloc.c
+++ b/sdk/tlibc/stdlib/malloc.c
@@ -733,7 +733,7 @@ typedef int LONG;
 #define NO_MALLINFO 0
 #endif  /* NO_MALLINFO */
 #ifndef MALLINFO_FIELD_TYPE
-#define MALLINFO_FIELD_TYPE size_t
+#define MALLINFO_FIELD_TYPE int
 #endif  /* MALLINFO_FIELD_TYPE */
 #ifndef NO_MALLOC_STATS
 #define NO_MALLOC_STATS 0


### PR DESCRIPTION
This PR changes the fields of `struct mallinfo` to int.

In standard malloc.h the fields of `struct mallinfo` are int, whereas in the sgx malloc.c they are defined as size_t. This causes incorrect stack allocations when calling `mallinfo()` and subsequent segfaults once the function returns(on 64bit).
