### PR TITLE
Bug fix - mprotect may be called with wrong flags

### DIFF
--- a/psw/urts/loader.cpp
+++ b/psw/urts/loader.cpp
@@ -752,7 +752,7 @@ int CLoader::set_context_protection(layout_t *layout_start, layout_t *layout_end
         if (!IS_GROUP_ID(layout->group.id))
         {
             int prot = 0 ;
-            if(layout->entry.attributes == SI_FLAG_NONE)
+            if(layout->entry.si_flags == SI_FLAG_NONE)
             {
                 prot = SI_FLAG_NONE & SI_MASK_MEM_ATTRIBUTE;
             }


### PR DESCRIPTION
Query si_flags instead of attributes when determining whether a layout
entry should be readable/writable or not accessible.  The current code
magically works because all layout entries that should be marked R/W
will have a non-zero value for attributes since added pages are marked
with either ADD_EXTEND_PAGE or ADD_EXTEND_PAGE.

Signed-off-by: Sean Christopherson <sean.j.christopherson@intel.com>