### PR TITLE
ECDSA API cleanups

### DIFF
--- a/common/inc/sgx_tcrypto.h
+++ b/common/inc/sgx_tcrypto.h
@@ -563,10 +563,10 @@ extern "C" {
     *   Output: ec256_signature_t *p_signature - Pointer to the signature - LITTLE ENDIAN
     */
     sgx_status_t SGXAPI sgx_ecdsa_sign(const uint8_t *p_data,
-                                    uint32_t data_size,
-                                    sgx_ec256_private_t *p_private,
-                                    sgx_ec256_signature_t *p_signature,
-                                    sgx_ecc_state_handle_t ecc_handle);
+                                       uint32_t data_size,
+                                       const sgx_ec256_private_t *p_private,
+                                       sgx_ec256_signature_t *p_signature,
+                                       sgx_ecc_state_handle_t ecc_handle);
 
    /** Verifies the signature for the given data based on the public key.
     *
@@ -594,11 +594,11 @@ extern "C" {
     *   Output: uint8_t *p_result - Pointer to the result of verification check
     */
     sgx_status_t SGXAPI sgx_ecdsa_verify(const uint8_t *p_data,
-                                        uint32_t data_size,
-                                        const sgx_ec256_public_t *p_public,
-                                        sgx_ec256_signature_t *p_signature,
-                                        uint8_t *p_result,
-                                        sgx_ecc_state_handle_t ecc_handle);
+                                         uint32_t data_size,
+                                         const sgx_ec256_public_t *p_public,
+                                         const sgx_ec256_signature_t *p_signature,
+                                         sgx_generic_ecresult_t *p_result,
+                                         sgx_ecc_state_handle_t ecc_handle);
 
 #ifdef __cplusplus
 }

--- a/psw/ae/aesm_service/source/aesm/extension/aesm_ecdsa.cpp
+++ b/psw/ae/aesm_service/source/aesm/extension/aesm_ecdsa.cpp
@@ -37,7 +37,7 @@
 
 ae_error_t aesm_check_pek_signature(const signed_pek_t& signed_pek, const extended_epid_group_blob_t& xegb)
 {
-    uint8_t result = SGX_EC_INVALID_SIGNATURE;
+    sgx_generic_ecresult_t result = SGX_EC_INVALID_SIGNATURE;
     uint32_t i;
     sgx_status_t sgx_code;
     const uint8_t *p = (const uint8_t *)&xegb;
@@ -64,7 +64,7 @@ ae_error_t aesm_check_pek_signature(const signed_pek_t& signed_pek, const extend
 
 ae_error_t aesm_verify_xegb(const extended_epid_group_blob_t& signed_xegb)
 {
-    uint8_t result = SGX_EC_INVALID_SIGNATURE;
+    sgx_generic_ecresult_t result = SGX_EC_INVALID_SIGNATURE;
     sgx_status_t sgx_code = verify_xegb(signed_xegb, &result);
     if (sgx_code == SGX_ERROR_INVALID_PARAMETER)
         return AE_INVALID_PARAMETER; 

--- a/psw/ae/aesm_service/source/upse/u_certificate_provisioning.cpp
+++ b/psw/ae/aesm_service/source/upse/u_certificate_provisioning.cpp
@@ -685,7 +685,7 @@ ae_error_t pib_verify_signature(platform_info_blob_wrapper_t& piBlobWrapper)
     ae_error_t ae_err = AE_FAILURE;
     sgx_ecc_state_handle_t ecc_handle = NULL;
 
-    uint8_t result = SGX_EC_INVALID_SIGNATURE;
+    sgx_generic_ecresult_t result = SGX_EC_INVALID_SIGNATURE;
 
     const uint32_t data_size = static_cast<uint32_t>(sizeof(piBlobWrapper.platform_info_blob) - sizeof(piBlobWrapper.platform_info_blob.signature));
 

--- a/psw/ae/common/pek_pub_key.cpp
+++ b/psw/ae/common/pek_pub_key.cpp
@@ -43,7 +43,7 @@
 
 //Function to verify the ECDSA signature of a PEK
 //SHA1 value for integrity checking is not verified since the ECDSA verification could make sure the integrity at the same time.
-sgx_status_t check_pek_signature(const signed_pek_t& signed_pek, const sgx_ec256_public_t* pek_sk, uint8_t *result)
+sgx_status_t check_pek_signature(const signed_pek_t& signed_pek, const sgx_ec256_public_t* pek_sk, sgx_generic_ecresult_t *result)
 {
     sgx_status_t status = SGX_SUCCESS;
     sgx_ecc_state_handle_t handle= 0;
@@ -67,7 +67,7 @@ sgx_status_t check_pek_signature(const signed_pek_t& signed_pek, const sgx_ec256
 }
 
 //Function to verify that ECDSA signature of XEGB is correct
-sgx_status_t verify_xegb(const extended_epid_group_blob_t& xegb, uint8_t *result){
+sgx_status_t verify_xegb(const extended_epid_group_blob_t& xegb, sgx_generic_ecresult_t *result){
     if (lv_htons(xegb.data_length) != EXTENDED_EPID_GROUP_BLOB_DATA_LEN
         || xegb.format_id != XEGB_FORMAT_ID){
         return SGX_ERROR_INVALID_PARAMETER;
@@ -97,7 +97,7 @@ sgx_status_t verify_xegb(const extended_epid_group_blob_t& xegb, uint8_t *result
     return SGX_SUCCESS;
 }
 
-sgx_status_t verify_xegb_with_default(const extended_epid_group_blob_t& xegb, uint8_t *result, extended_epid_group_blob_t& out_xegb)
+sgx_status_t verify_xegb_with_default(const extended_epid_group_blob_t& xegb, sgx_generic_ecresult_t *result, extended_epid_group_blob_t& out_xegb)
 {
     const uint8_t *pxegb = reinterpret_cast<const uint8_t *>(&xegb);
     uint32_t i;

--- a/psw/ae/inc/internal/pek_pub_key.h
+++ b/psw/ae/inc/internal/pek_pub_key.h
@@ -37,8 +37,8 @@
 #include "epid_pve_type.h"
 
 
-sgx_status_t check_pek_signature(const signed_pek_t& signed_pek, const sgx_ec256_public_t* pek_sk, uint8_t *result);
-sgx_status_t verify_xegb(const extended_epid_group_blob_t& xegb, uint8_t *result);
-sgx_status_t verify_xegb_with_default(const extended_epid_group_blob_t& xegb, uint8_t *result, extended_epid_group_blob_t& out_xegb);
+sgx_status_t check_pek_signature(const signed_pek_t& signed_pek, const sgx_ec256_public_t* pek_sk, sgx_generic_ecresult_t *result);
+sgx_status_t verify_xegb(const extended_epid_group_blob_t& xegb, sgx_generic_ecresult_t *result);
+sgx_status_t verify_xegb_with_default(const extended_epid_group_blob_t& xegb, sgx_generic_ecresult_t *result, extended_epid_group_blob_t& out_xegb);
 #endif
 

--- a/sdk/tkey_exchange/tkey_exchange.cpp
+++ b/sdk/tkey_exchange/tkey_exchange.cpp
@@ -216,12 +216,12 @@ extern "C" sgx_status_t sgx_ra_proc_msg2_trusted(
         return se_ret;
     }
     // Verify signature of gb_ga
-    uint8_t result;
+    sgx_generic_ecresult_t result;
     sgx_ec256_signature_t* p_msg2_sign_gb_ga = const_cast<sgx_ec256_signature_t*>(&p_msg2->sign_gb_ga);
     se_ret = sgx_ecdsa_verify((uint8_t *)&gb_ga, sizeof(gb_ga),
-        &sp_pubkey,
-        p_msg2_sign_gb_ga,
-        &result, ecc_state);
+                              &sp_pubkey,
+                              p_msg2_sign_gb_ga,
+                              &result, ecc_state);
     if(SGX_SUCCESS != se_ret)
     {
         if (SGX_ERROR_OUT_OF_MEMORY != se_ret)

--- a/sdk/tlibcrypto/sgx_ecc256_ecdsa.cpp
+++ b/sdk/tlibcrypto/sgx_ecc256_ecdsa.cpp
@@ -48,7 +48,7 @@ const uint32_t sgx_nistp256_r[] = {
 *   Output: sgx_ec256_signature_t *p_signature - Pointer to the signature - LITTLE ENDIAN  */
 sgx_status_t sgx_ecdsa_sign(const uint8_t *p_data,
                             uint32_t data_size,
-                            sgx_ec256_private_t *p_private,
+                            const sgx_ec256_private_t *p_private,
                             sgx_ec256_signature_t *p_signature,
                             sgx_ecc_state_handle_t ecc_handle)
 {
@@ -186,8 +186,8 @@ sgx_status_t sgx_ecdsa_sign(const uint8_t *p_data,
 sgx_status_t sgx_ecdsa_verify(const uint8_t *p_data,
                               uint32_t data_size,
                               const sgx_ec256_public_t *p_public,
-                              sgx_ec256_signature_t *p_signature,
-                              uint8_t *p_result,
+                              const sgx_ec256_signature_t *p_signature,
+                              sgx_generic_ecresult_t *p_result,
                               sgx_ecc_state_handle_t ecc_handle)
 {
     if ((ecc_handle == NULL) || (p_public == NULL) || (p_signature == NULL) ||


### PR DESCRIPTION
Imho this makes the ECDSA API a little cleaner.
Sorry, if there was a reason to use uint8_t instead of sgx_generic_ecresult_t.

Also, I'm not really sure why verify has two return values and if they're both needed.