### PR TITLE
Add support for running the AESM and SGX applications in Docker

### DIFF
--- a/linux/installer/common/psw/install.sh
+++ b/linux/installer/common/psw/install.sh
@@ -54,6 +54,15 @@ chmod  0644 /etc/aesmd.conf
 chown -R aesmd /var/opt/aesmd
 chmod 0750 /var/opt/aesmd
 
+# By default the AESM's communication socket will be created in
+# /var/run/aesmd.  Putting the socket in the aesmd sub-directory
+# as opposed to directly in /var/run allows the user to create a
+# mount a volume at /var/run/aesmd and thus expose the socket to
+# a different filesystem or namespace, e.g. a Docker container.
+mkdir -p /var/run/aesmd
+chown -R aesmd /var/run/aesmd
+chmod 0755 /var/run/aesmd
+
 if [ -d /run/systemd/system ]; then
     AESMD_NAME=aesmd.service
     AESMD_TEMP=$AESM_PATH/$AESMD_NAME
@@ -112,8 +121,9 @@ $DISABLE_AESMD
 rm -f $AESMD_DEST
 rm -f /etc/aesmd.conf
 
-# Removing AESM internal folder
+# Removing AESM internal folders
 rm -fr /var/opt/aesmd
+rm -fr /var/run/aesmd
 
 # Removing runtime libraries
 rm -f /usr/lib/libsgx_uae_service.so

--- a/psw/ae/aesm_service/source/aesm/application/main.cpp
+++ b/psw/ae/aesm_service/source/aesm/application/main.cpp
@@ -73,8 +73,16 @@ void signal_handler(int sig)
     }
 }
 
-int main() {
-    if(daemon(0, 0) < 0)
+int main(int argc, char *argv[]) {
+    // The only command line option that is supported is --no-daemon.
+    bool noDaemon = argc == 2 && (strcmp(argv[1], "--no-daemon") == 0);
+    if ((argc > 2) || (argc == 2 && !noDaemon)) {
+        AESM_LOG_INIT();
+        AESM_LOG_FATAL("Invalid command line.");
+        AESM_LOG_FINI();
+        exit(1);
+    }
+    if(!noDaemon && daemon(0, 0) < 0)
     {
         AESM_LOG_INIT();
         AESM_LOG_FATAL("Fail to set daemon.");

--- a/psw/ae/aesm_service/source/aesm_wrapper/src/UnixServerSocket.cpp
+++ b/psw/ae/aesm_service/source/aesm_wrapper/src/UnixServerSocket.cpp
@@ -30,6 +30,7 @@
  */
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/un.h>
 #include <unistd.h>
 #include <errno.h>
@@ -45,8 +46,10 @@ UnixServerSocket::UnixServerSocket(const char* socketbase, const unsigned int cl
 }
 
 UnixServerSocket::~UnixServerSocket() {
-    if (mSocket > 0)
+    if (mSocket > 0) {
+        unlink(mSocketBase);
         close(mSocket);
+    }
 }
 
 void UnixServerSocket::init()
@@ -64,8 +67,7 @@ void UnixServerSocket::init()
 
     server_address.sun_family = AF_UNIX;
     memset(server_address.sun_path, 0, sizeof(server_address.sun_path));
-    // leave the first byte to 0 in order to have an abstract socket address
-    strncpy(server_address.sun_path + 1, mSocketBase, sizeof(server_address.sun_path) - 1);
+    strncpy(server_address.sun_path, mSocketBase, sizeof(server_address.sun_path));
     unlink(server_address.sun_path);
 
     socklen_t server_len = sizeof(server_address);
@@ -74,6 +76,8 @@ void UnixServerSocket::init()
         close(mSocket);
         throw("Failed to create socket");
     }
+
+    chmod(mSocketBase, 0777);
 
     rc = listen(mSocket, 32);
     if (rc < 0) {

--- a/psw/ae/common/inc/SocketConfig.h
+++ b/psw/ae/common/inc/SocketConfig.h
@@ -33,7 +33,7 @@
 
 
 #ifndef CONFIG_SOCKET_PATH
-    #define CONFIG_SOCKET_PATH "sgx_aesm_socket_base"
+    #define CONFIG_SOCKET_PATH "/var/run/aesmd/aesm.socket"
 #endif /* CONFIG_SOCKET_PATH */
 
 #endif

--- a/psw/ae/common/src/UnixCommunicationSocket.cpp
+++ b/psw/ae/common/src/UnixCommunicationSocket.cpp
@@ -208,8 +208,7 @@ bool UnixCommunicationSocket::init()
         memset(&serv_addr, 0, sizeof(struct sockaddr_un));
         serv_addr.sun_family = AF_UNIX;
         memset(serv_addr.sun_path, 0, sizeof(serv_addr.sun_path));
-        // leave the first byte to 0 in order to have an abstract socket address
-        strncpy(serv_addr.sun_path + 1, mSocketBase, sizeof(serv_addr.sun_path) - 1);
+        strncpy(serv_addr.sun_path, mSocketBase, sizeof(serv_addr.sun_path));
 
         if( connect(mSocket, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) != 0)
         {


### PR DESCRIPTION
This PR contains two functional modifications to the AESM to enable running SGX applications in Docker, along with scripts and files for running the AESM and SampleEnclave in separate Docker containers.

 - Bind the AESM socket to /var/run/aesmd/aesm.socket instead of an abstract socket.  Exposing sockets to Docker containers is typically done via bind mounts, which does not work for abstract sockets since they don't exist in the file system.
  - Add a --no-daemon option to the AESM service.  Application container runtimes, e.g. Docker and RKT, do not provide a program manager, e.g. systemd, inside the container, and so attempting to daemonize the AESM will fail.   The AESM will skip the call to daemon() if --no-daemon is specified.

**Note:** Users may need to remove or modify the proxy settings in the Dockerfiles, they are configured to work inside Intel's internal network.

**Note:** The Dockerfiles will not work as-is because they checkout the master branch from https://github.com/01org/linux-sgx; the PSW/SDK compiled inside the containers will not have the aforementioned changes until this PR is merged to master.  A branch that is runnable as-is can be found at https://github.com/sean-jc/linux-sgx/tree/c/docker.  The only difference is that the Dockerfiles are configured to clone and checkout https://github.com/sean-jc/linux-sgx/tree/c/docker instead of https://github.com/01org/linux-sgx.