### PR TITLE
fixed typo flase -> false in psw/urts/linux/urts.cpp:45

### DIFF
--- a/psw/urts/linux/urts.cpp
+++ b/psw/urts/linux/urts.cpp
@@ -42,7 +42,7 @@ extern "C" sgx_status_t sgx_create_enclave(const char *file_name, const int debu
 {
     sgx_status_t ret = SGX_SUCCESS;
 
-    //Only true or flase is valid
+    //Only true or false is valid
     if(TRUE != debug &&  FALSE != debug)
         return SGX_ERROR_INVALID_PARAMETER;
 


### PR DESCRIPTION
I fixed a tiny typo in psw/urts/linux/urts.cpp.

Signed-off-by: Eunchan Kim <eunchan.kim@kaist.ac.kr>