### PR TITLE
Fix sgx_metadata note section alignment

### DIFF
--- a/sdk/trts/linux/metadata_sec.S
+++ b/sdk/trts/linux/metadata_sec.S
@@ -39,4 +39,4 @@
     .long 0x01              /* type */
 0:  .asciz "sgx_metadata"   /* name */
 1:  .fill METADATA_SIZE, 1, 0      /* desc - stand for metadata which is initialized with 0 */
-2:  .p2align 0
+2:  .p2align 2


### PR DESCRIPTION
The metadata note section has incorrect alignment which confuses
standard tools like readelf

$ readelf -n -W metadata_sec.o

Displaying notes found at file offset 0x00000040 with length 0x00001019:
  Owner                 Data size       Description
readelf: Warning: note with invalid namesz and/or descsz found at offset
0x0
readelf: Warning:  type: 0x1, namesize: 0x0000000d, descsize: 0x00001000

According to elf spec (http://man7.org/linux/man-pages/man5/elf.5.html)
notes should be aligned on 2^2 boundary.