### PR TITLE
Close connection when detect `peerSocketClosed`

### DIFF
--- a/psw/ae/common/src/NonBlockingUnixCommunicationSocket.cpp
+++ b/psw/ae/common/src/NonBlockingUnixCommunicationSocket.cpp
@@ -209,7 +209,7 @@ char* NonBlockingUnixCommunicationSocket::readRaw(ssize_t length)
     
         if (total_read != length)
         {
-            if (errorDetected || cancellationDetected || wasTimeoutDetected())
+            if (errorDetected || cancellationDetected || wasTimeoutDetected() || peerSocketClosed)
             {
                 disconnect();
                 delete [] recBuf;


### PR DESCRIPTION
Fix [issue 101](https://github.com/01org/linux-sgx/issues/101)

`peerSocketClosed` is detected in NonBlockingUnixCommunicationSocket::readRaw. However, this flag is not used, cause the connection always exist. 

This PR add this flag in the condition to disconnect, thus when `peerSocketClosed` is detected, the related socket will be closed.

Signed-off-by: Hui Wang <hw.huiwang@huawei.com>