### PR TITLE
Changing psw and sdk version in prebuilt file

### DIFF
--- a/download_prebuilt.sh
+++ b/download_prebuilt.sh
@@ -33,8 +33,8 @@
 
 top_dir=`dirname $0`
 out_dir=$top_dir
-optlib_name=optimized_libs-1.9.100.38927.tar
-ae_file_name=prebuilt-ae-1.9.100.38927.tar
+optlib_name=optimized_libs-1.9.100.39124.tar
+ae_file_name=prebuilt-ae-1.9.100.39124.tar
 server_url_path=https://download.01.org/intel-sgx/linux-1.9/
 server_optlib_url=$server_url_path/$optlib_name
 server_ae_url=$server_url_path/$ae_file_name


### PR DESCRIPTION
There is an issue while downloading the psw and sdk in prebuild file. The correct version is 39124, nor 38927. 