### PR TITLE
Improve const correctness of sgx_fopen and sgx_fimport_auto_key.

### DIFF
--- a/common/inc/sgx_tprotected_fs.h
+++ b/common/inc/sgx_tprotected_fs.h
@@ -74,7 +74,7 @@ extern "C" {
  *  Return value:
  *     SGX_FILE*  - pointer to the newly created file handle, NULL if an error occurred - check errno for the error code.
 */
-SGX_FILE* SGXAPI sgx_fopen(const char* filename, const char* mode, sgx_key_128bit_t *key);
+SGX_FILE* SGXAPI sgx_fopen(const char* filename, const char* mode, const sgx_key_128bit_t *key);
 
 
 /* sgx_fopen_auto_key
@@ -252,7 +252,7 @@ int32_t SGXAPI sgx_fexport_auto_key(const char* filename, sgx_key_128bit_t *key)
 *  Return value:
 *     int32_t  - result, 0 - success, 1 - there was an error, check errno for the error code
 */
-int32_t SGXAPI sgx_fimport_auto_key(const char* filename, sgx_key_128bit_t *key);
+int32_t SGXAPI sgx_fimport_auto_key(const char* filename, const sgx_key_128bit_t *key);
 
 
 /* sgx_fclear_cache

--- a/sdk/protected_fs/sgx_tprotected_fs/file_crypto.cpp
+++ b/sdk/protected_fs/sgx_tprotected_fs/file_crypto.cpp
@@ -238,7 +238,7 @@ bool protected_fs_file::generate_random_meta_data_key()
 }
 
 
-bool protected_fs_file::restore_current_meta_data_key(sgx_aes_gcm_128bit_key_t* import_key)
+bool protected_fs_file::restore_current_meta_data_key(const sgx_aes_gcm_128bit_key_t* import_key)
 {
 	if (import_key != NULL)
 	{		

--- a/sdk/protected_fs/sgx_tprotected_fs/file_init.cpp
+++ b/sdk/protected_fs/sgx_tprotected_fs/file_init.cpp
@@ -67,7 +67,7 @@ bool protected_fs_file::cleanup_filename(const char* src, char* dest)
 }
 
 
-protected_fs_file::protected_fs_file(const char* filename, const char* mode, sgx_aes_gcm_128bit_key_t* import_key, sgx_aes_gcm_128bit_key_t* kdk_key)
+protected_fs_file::protected_fs_file(const char* filename, const char* mode, const sgx_aes_gcm_128bit_key_t* import_key, const sgx_aes_gcm_128bit_key_t* kdk_key)
 {
 	sgx_status_t status = SGX_SUCCESS;
 	uint8_t result = 0;
@@ -385,7 +385,7 @@ bool protected_fs_file::file_recovery(const char* filename)
 }
 
 
-bool protected_fs_file::init_existing_file(const char* filename, const char* clean_filename, sgx_aes_gcm_128bit_key_t* import_key)
+bool protected_fs_file::init_existing_file(const char* filename, const char* clean_filename, const sgx_aes_gcm_128bit_key_t* import_key)
 {
 	sgx_status_t status;
 	int32_t result32;

--- a/sdk/protected_fs/sgx_tprotected_fs/protected_fs_file.h
+++ b/sdk/protected_fs/sgx_tprotected_fs/protected_fs_file.h
@@ -187,7 +187,7 @@ private:
 	bool cleanup_filename(const char* src, char* dest);
 	bool parse_mode(const char* mode);
 	bool file_recovery(const char* filename);
-	bool init_existing_file(const char* filename, const char* clean_filename, sgx_aes_gcm_128bit_key_t* import_key);
+	bool init_existing_file(const char* filename, const char* clean_filename, const sgx_aes_gcm_128bit_key_t* import_key);
 	bool init_new_file(const char* clean_filename);
 	
 	bool generate_secure_blob(sgx_aes_gcm_128bit_key_t* key, const char* label, uint64_t physical_node_number, sgx_aes_gcm_128bit_tag_t* output);
@@ -195,7 +195,7 @@ private:
 	bool init_session_master_key();
 	bool derive_random_node_key(uint64_t physical_node_number);
 	bool generate_random_meta_data_key();
-	bool restore_current_meta_data_key(sgx_aes_gcm_128bit_key_t* import_key);
+	bool restore_current_meta_data_key(const sgx_aes_gcm_128bit_key_t* import_key);
 	
 	
 	file_data_node_t* get_data_node();
@@ -214,7 +214,7 @@ private:
 	bool internal_flush(/*bool mc,*/ bool flush_to_disk);
 
 public:
-	protected_fs_file(const char* filename, const char* mode, sgx_aes_gcm_128bit_key_t* import_key, sgx_aes_gcm_128bit_key_t* kdk_key);
+	protected_fs_file(const char* filename, const char* mode, const sgx_aes_gcm_128bit_key_t* import_key, const sgx_aes_gcm_128bit_key_t* kdk_key);
 	~protected_fs_file();
 
 	size_t write(const void* ptr, size_t size, size_t count);

--- a/sdk/protected_fs/sgx_tprotected_fs/sgx_tprotected_fs.cpp
+++ b/sdk/protected_fs/sgx_tprotected_fs/sgx_tprotected_fs.cpp
@@ -36,7 +36,7 @@
 #include <errno.h>
 
 
-static SGX_FILE* sgx_fopen_internal(const char* filename, const char* mode, sgx_key_128bit_t *auto_key, sgx_key_128bit_t *kdk_key)
+static SGX_FILE* sgx_fopen_internal(const char* filename, const char* mode, const sgx_key_128bit_t *auto_key, const sgx_key_128bit_t *kdk_key)
 {
 	protected_fs_file* file = NULL;
 
@@ -72,7 +72,7 @@ SGX_FILE* sgx_fopen_auto_key(const char* filename, const char* mode)
 }
 
 
-SGX_FILE* sgx_fopen(const char* filename, const char* mode, sgx_key_128bit_t *key)
+SGX_FILE* sgx_fopen(const char* filename, const char* mode, const sgx_key_128bit_t *key)
 {
 	return sgx_fopen_internal(filename, mode, NULL, key);
 }
@@ -230,7 +230,7 @@ int32_t sgx_fexport_auto_key(const char* filename, sgx_key_128bit_t *key)
 }
 
 
-int32_t sgx_fimport_auto_key(const char* filename, sgx_key_128bit_t *key)
+int32_t sgx_fimport_auto_key(const char* filename, const sgx_key_128bit_t *key)
 {
 	SGX_FILE* stream = sgx_fopen_internal(filename, "r+", key, NULL);
 	if (stream == NULL)


### PR DESCRIPTION
* Makes the interface easier to understand. Eliminates the mismatch
  between [IN] parameters and their types. It is no longer as easy to
  mix key import and export functions.
* Makes the interface compatible with other const-correct code.

Signed-off-by: Jaak Randmets <jaak.randmets@cyber.ee>