### PR TITLE
Check for crash in do_ocall to prevent any data leakage.

### DIFF
--- a/sdk/trts/trts_ocall.cpp
+++ b/sdk/trts/trts_ocall.cpp
@@ -53,6 +53,10 @@ extern "C" sgx_status_t __morestack(const unsigned int index, void *ms);
 //
 sgx_status_t sgx_ocall(const unsigned int index, void *ms)
 {
+    // check for crash to prevent any data leakage
+    if(get_enclave_state() == ENCLAVE_CRASHED) {
+        return SGX_ERROR_ENCLAVE_CRASHED;
+    }
     // sgx_ocall is not allowed during exception handling
     thread_data_t *thread_data = get_thread_data();
     
@@ -138,4 +142,3 @@ sgx_status_t do_oret(void *ms)
     // Should not come here
     return SGX_ERROR_UNEXPECTED;
 }
-


### PR DESCRIPTION
This PR is a hardening measure, as there is no real way to "safely abort" from a multithreaded user-space program without OS assistance or defensive coding on behalf of the user.

Enclaves threads run in user space, so there is no way to signal to other threads to abort other than with shared state or depending on an untrusted operating system. When one thread aborts, g_enclave_state is set to $ENCLAVE_CRASHED, so another thread that might be reading from corrupted state (because we aborted on an error condition) is prevented from exposing secrets accidentally. This doesn't stop other threads from directly manipulating untrusted memory (possibly in a loop), but a loop will likely call something similar to `sched_yield` (implemented as an ocall to the host) and then be stopped by the check in `do_ocall`.

Consider exposing an SDK call in `sdk/trts/trts.cpp` (declared in `common/inc/sgx_trts.h`) for defensive programming,
```
int sgx_is_enclave_crashed() {
  return get_enclave_state() == ENCLAVE_CRASHED;
}
```