### PR TITLE
Fix potential false alarm of stack smashing attack

### DIFF
--- a/sdk/trts/trts.cpp
+++ b/sdk/trts/trts.cpp
@@ -38,8 +38,6 @@
 #include "thread_data.h"
 #include "global_data.h"
 
-#include "internal/rts.h"
-
 #ifdef SE_SIM
 #include "t_instructions.h"    /* for `g_global_data_sim' */
 #include "sgx_spinlock.h"
@@ -285,39 +283,4 @@ sgx_status_t sgx_read_rand(unsigned char *rand, size_t length_in_bytes)
     }
     memset_s(&rand_num, sizeof(rand_num), 0, sizeof(rand_num));
     return SGX_SUCCESS;
-}
-
-#include "trts_internal.h"
-extern "C" int enter_enclave(int index, void *ms, void *tcs, int cssa)
-{
-    if(get_enclave_state() == ENCLAVE_CRASHED)
-    {
-        return SGX_ERROR_ENCLAVE_CRASHED;
-    }
-
-    sgx_status_t error = SGX_ERROR_UNEXPECTED;
-    if(cssa == 0)
-    {
-        if(index >= 0)
-        {
-            error = do_ecall(index, ms, tcs);
-        }
-        else if(index == ECMD_INIT_ENCLAVE)
-        {
-            error = do_init_enclave(ms);
-        }
-        else if(index == ECMD_ORET)
-        {
-            error = do_oret(ms);
-        }
-    }
-    else if((cssa == 1) && (index == ECMD_EXCEPT))
-    {
-        error = trts_handle_exception(tcs);
-    }
-    if(error == SGX_ERROR_UNEXPECTED)
-    {
-        set_enclave_state(ENCLAVE_CRASHED);
-    }
-    return error;
 }

--- a/sdk/trts/trts_ecall.cpp
+++ b/sdk/trts/trts_ecall.cpp
@@ -99,7 +99,7 @@ static volatile bool           g_is_first_ecall = true;
 static volatile sgx_spinlock_t g_ife_lock       = SGX_SPINLOCK_INITIALIZER;
 
 typedef sgx_status_t (*ecall_func_t)(void *ms);
-static sgx_status_t trts_ecall(uint32_t ordinal, void *ms)
+sgx_status_t trts_ecall(uint32_t ordinal, void *ms)
 {
     if (unlikely(g_is_first_ecall))
     {
@@ -132,25 +132,3 @@ static sgx_status_t trts_ecall(uint32_t ordinal, void *ms)
     CLEAN_XFEATURE_REGS
     return status;
 }
-
-extern "C" sgx_status_t do_init_thread(void *tcs);
-sgx_status_t do_ecall(int index, void *ms, void *tcs)
-{
-    sgx_status_t status = SGX_ERROR_UNEXPECTED;
-    if(ENCLAVE_INIT_DONE != get_enclave_state())
-    {
-        return status;
-    }
-    thread_data_t *thread_data = get_thread_data();
-    if( (NULL == thread_data) || ((thread_data->stack_base_addr == thread_data->last_sp) && (0 != g_global_data.thread_policy)))
-    {
-        status = do_init_thread(tcs);
-        if(0 != status)
-        {
-            return status;
-        }
-    }
-    status = trts_ecall(index, ms);
-    return status;
-}
-

--- a/sdk/trts/trts_internal.h
+++ b/sdk/trts/trts_internal.h
@@ -69,7 +69,7 @@ int get_enclave_state();
 void set_enclave_state(int state);
 
 sgx_status_t do_init_enclave(void *ms);
-sgx_status_t do_ecall(int index, void *ms, void *tcs);
+sgx_status_t trts_ecall(uint32_t ordinal, void *ms);
 sgx_status_t do_oret(void *ms);
 sgx_status_t trts_handle_exception(void *tcs);
 #ifdef __cplusplus


### PR DESCRIPTION
This PR makes sure all TRTS functions during which the stack guard (or canary value) may be initialized are compiled without `-fstack-protector-strong`. Currently, functions (in `trts_nsp.cpp`) that directly deal with stack guard initialization are correctly compiled without `-fstack-protector-strong`; yet, the callers of these functions (`do_ecall()` in `trts_ecall.cpp` and `enter_enclave()` in `trts.cpp`) are not. This makes the code of `enter_enclave()` and `do_ecall()` very fragile (see the example below) since any code changes that cause the compiler to add stack protection logic for these two functions would break them. This PR simply moves the code of `do_ecall()` and `enter_enclave()` to `trts_nsp.cpp`. As the file name of `trts_nsp.cpp` suggests, it is where No-Stack-Protection code are supposed to be anyway.

Here is an example of how seemingly innocent code changes could break `do_ecall()`, causing Illegal Instruction error upon the first ECall to any enclave compiled:

    diff --git a/sdk/trts/trts.cpp b/sdk/trts/trts.cpp
    index 9bbdb5e..a909117 100644
    --- a/sdk/trts/trts.cpp
    +++ b/sdk/trts/trts.cpp
    @@ -321,3 +321,7 @@ extern "C" int enter_enclave(int index, void *ms, void *tcs, int cssa)
         }
         return error;
     }
    +
    +extern "C" int reproduce_bug(int* a) {
    +    return *a;
    +}
    diff --git a/sdk/trts/trts_ecall.cpp b/sdk/trts/trts_ecall.cpp
    index 1de3cfc..310b881 100644
    --- a/sdk/trts/trts_ecall.cpp
    +++ b/sdk/trts/trts_ecall.cpp
    @@ -124,6 +124,9 @@ static sgx_status_t trts_ecall(uint32_t ordinal, void *ms)
         sgx_status_t status = get_func_addr(ordinal, &addr);
         if(status == SGX_SUCCESS)
         {
    +        int a = 1;
    +        reproduce_bug(&a);
    +
             ecall_func_t func = (ecall_func_t)addr;
             status = func(ms);
         }
    diff --git a/sdk/trts/trts_internal.h b/sdk/trts/trts_internal.h
    index 28c0f48..bcbb54e 100644
    --- a/sdk/trts/trts_internal.h
    +++ b/sdk/trts/trts_internal.h
    @@ -72,6 +72,9 @@ sgx_status_t do_init_enclave(void *ms);
     sgx_status_t do_ecall(int index, void *ms, void *tcs);
     sgx_status_t do_oret(void *ms);
     sgx_status_t trts_handle_exception(void *tcs);
    +int reproduce_bug(int* a);
     #ifdef __cplusplus
     }
     #endif

Use this patch with `git apply` on any commits since 1.9 release, compile the SDK, and try any project under `SampleCode`. The sample enclaves will always report Illegal Instruction error.

 

