### PR TITLE
Check for crash in sgx_ocall and exit enclave if enclave is crashed

### DIFF
--- a/sdk/trts/linux/trts_pic.S
+++ b/sdk/trts/linux/trts_pic.S
@@ -190,6 +190,13 @@ DECLARE_GLOBAL_FUNC enclave_entry
     
     .cfi_endproc
 
+DECLARE_GLOBAL_FUNC force_exit_enclave
+    READ_TD_DATA last_sp
+    sub     $(2*SE_WORDSIZE), %xax
+    mov     %xax, %xbp
+    mov     $SGX_ERROR_ENCLAVE_CRASHED, %xbx
+    jmp     .Lexit_enclave
+
 /* 
  * -------------------------------------------------------------------------
  *  sgx_status_t do_ocall(unsigned int index, void *ms);

--- a/sdk/trts/trts_ocall.cpp
+++ b/sdk/trts/trts_ocall.cpp
@@ -39,6 +39,7 @@
 #include "xsave.h"
 #include "trts_internal.h"
 
+extern "C" void force_exit_enclave();
 extern "C" sgx_status_t asm_oret(uintptr_t sp, void *ms);
 extern "C" sgx_status_t __morestack(const unsigned int index, void *ms);
 #define do_ocall __morestack
@@ -53,6 +54,10 @@ extern "C" sgx_status_t __morestack(const unsigned int index, void *ms);
 //
 sgx_status_t sgx_ocall(const unsigned int index, void *ms)
 {
+    if(get_enclave_state() == ENCLAVE_CRASHED) {
+        force_exit_enclave();
+    }
+
     // sgx_ocall is not allowed during exception handling
     thread_data_t *thread_data = get_thread_data();
     


### PR DESCRIPTION
This is an alternative solution for PR #138 - enclave state check in sgx_ocall. tRTS check the enclave crash state when doing an OCALL. If the enclave is crashed, tRTS unwind the stack to ECALL, and exit the enclave with SGX_ERROR_ENCLAVE_CRASHED.

Signed-off-by: Yu Yuan <yuan.yu@intel.com>