### PR TITLE
Correct typos in some of the sample apps.

### DIFF
--- a/SampleCode/Cxx11SGXDemo/README.txt
+++ b/SampleCode/Cxx11SGXDemo/README.txt
@@ -18,7 +18,7 @@ The project demonstrates serveral C++11 features inside the Enclave:
 - function object wrapper;
 - atomic, mutexes, condition_variables;
 - new smart pointer classes: shared_ptr, unique_ptr;
-- new c++ algorithms: all_off, any_of, none_of;
+- new c++ algorithms: all_of, any_of, none_of;
 - variadic templates;
 - SFINAE;
 

--- a/SampleCode/SealedData/DRM_app/DRM_app.cpp
+++ b/SampleCode/SealedData/DRM_app/DRM_app.cpp
@@ -149,7 +149,7 @@ uint32_t test_replay_protected_drm_update_limitation()
         if(!result)
         {
             result = 1;
-            cerr<<"\tUnexpcted success."<<endl
+            cerr<<"\tUnexpected success."<<endl
                 <<"\tFailed to catch update limitation."<<endl;
         }
     }while(0);
@@ -200,7 +200,7 @@ uint32_t test_replay_protected_drm_replay_attack_protection()
             <<"\tReplay attack to DRM functions is caught."<<endl;
         else
         {
-            cerr<<"\tUnexpcted success."<<endl
+            cerr<<"\tUnexpected success."<<endl
             <<"\tReplay attack to DRM functions is NOT caught."<<endl;
             result = 1;
             break;
@@ -277,7 +277,7 @@ uint32_t test_time_based_policy_expiration()
     }
     else
     {
-        cerr<<"\tUnexpcted success."<<endl
+        cerr<<"\tUnexpected success."<<endl
             <<"\tTime based policy failed to catch expiration."<<endl;
         return 1;
     }

--- a/SampleCode/SealedData/DRM_enclave/DRM_enclave.cpp
+++ b/SampleCode/SealedData/DRM_enclave/DRM_enclave.cpp
@@ -114,11 +114,11 @@ static uint32_t verify_sealed_data(
             break;
         case SGX_ERROR_INVALID_ISVSVN:
             /* Indicates isv_svn field of the sealed data is greater than
-            the enclave’s ISVSVN. This is a downgraded enclave.*/
+            the enclaveâ€™s ISVSVN. This is a downgraded enclave.*/
             break;
         case SGX_ERROR_INVALID_CPUSVN:
             /* Indicates cpu_svn field of the sealed data is greater than
-            the platform’s cpu_svn. enclave is  on a downgraded platform.*/
+            the platformâ€™s cpu_svn. enclave is  on a downgraded platform.*/
             break;
         case SGX_ERROR_INVALID_KEYNAME:
             /*Indicates key_name field of the sealed data is incorrect.*/
@@ -309,7 +309,7 @@ uint32_t update_sealed_policy(uint8_t* sealed_log, uint32_t sealed_log_size)
         }
 
         /* If the counter value returns doesn't match the expected value,
-        someother entity has updated the counter, for example, another instance
+        some other entity has updated the counter, for example, another instance
         of this enclave. The system might be under attack */
         if(data2seal.mc_value!= data_unsealed.mc_value+1)
         {
@@ -504,11 +504,11 @@ uint32_t perform_time_based_policy(const uint8_t* sealed_log,
             break;
         case SGX_ERROR_INVALID_ISVSVN:
             /* Indicates isv_svn field of the sealed data is greater than the
-            enclave’s ISVSVN. This is a downgraded enclave.*/
+            enclaveâ€™s ISVSVN. This is a downgraded enclave.*/
             break;
         case SGX_ERROR_INVALID_CPUSVN:
             /* Indicates cpu_svn field of the sealed data is greater than the
-            platform’s cpu_svn. enclave is  on a downgraded platform.*/
+            platformâ€™s cpu_svn. enclave is  on a downgraded platform.*/
             break;
         case SGX_ERROR_INVALID_KEYNAME:
             /*Indicates key_name field of the sealed data is incorrect.*/


### PR DESCRIPTION
Fixes typos in the comments for the DRM sample and the README of the Cxx11SGX sample.