### PR TITLE
Revert "Check for crash in sgx_ocall and exit enclave if enclave is crashed"

### DIFF
--- a/sdk/trts/linux/trts_pic.S
+++ b/sdk/trts/linux/trts_pic.S
@@ -190,13 +190,6 @@ DECLARE_GLOBAL_FUNC enclave_entry
     
     .cfi_endproc
 
-DECLARE_GLOBAL_FUNC force_exit_enclave
-    READ_TD_DATA last_sp
-    sub     $(2*SE_WORDSIZE), %xax
-    mov     %xax, %xbp
-    mov     $SGX_ERROR_ENCLAVE_CRASHED, %xbx
-    jmp     .Lexit_enclave
-
 /* 
  * -------------------------------------------------------------------------
  *  sgx_status_t do_ocall(unsigned int index, void *ms);

--- a/sdk/trts/trts_ocall.cpp
+++ b/sdk/trts/trts_ocall.cpp
@@ -39,7 +39,6 @@
 #include "xsave.h"
 #include "trts_internal.h"
 
-extern "C" void force_exit_enclave();
 extern "C" sgx_status_t asm_oret(uintptr_t sp, void *ms);
 extern "C" sgx_status_t __morestack(const unsigned int index, void *ms);
 #define do_ocall __morestack
@@ -54,10 +53,6 @@ extern "C" sgx_status_t __morestack(const unsigned int index, void *ms);
 //
 sgx_status_t sgx_ocall(const unsigned int index, void *ms)
 {
-    if(get_enclave_state() == ENCLAVE_CRASHED) {
-        force_exit_enclave();
-    }
-
     // sgx_ocall is not allowed during exception handling
     thread_data_t *thread_data = get_thread_data();
     


### PR DESCRIPTION
Reverts 01org/linux-sgx#151

When the tRTS checks for a crash in the OCALL, the parameters have already been put on the outside stack. So unwind stack here doesn't improve security.
