### PR TITLE
Ensure trts_nsp.cpp is compiled without stack protection.

### DIFF
--- a/sdk/trts/Makefile
+++ b/sdk/trts/Makefile
@@ -40,7 +40,7 @@ CXXFLAGS += $(ENCLAVE_CXXFLAGS) \
             -fno-exceptions \
             -fno-rtti
 
-TCXXFLAGS := $(filter-out -fstack-protector-strong, $(CXXFLAGS))
+TCXXFLAGS := $(patsubst -fstack-protector%,-fno-stack-protector,$(CXXFLAGS))
 
 OBJS1 := init_enclave.o  \
         trts.o           \


### PR DESCRIPTION
This file must _not_ be compiled with `-fstack-protector-strong`. Removing the compiler option is not enough because the compiler may apply `-fstack-protector-strong` anyway by default. We _need_ to specify an explicit compiler option to disable it properly.