### PR TITLE
Fix to a static library linking problem.

### DIFF
--- a/sdk/protected_fs/sgx_tprotected_fs/Makefile
+++ b/sdk/protected_fs/sgx_tprotected_fs/Makefile
@@ -55,7 +55,7 @@ all: $(LIBNAME) | $(BUILD_DIR)
 	@$(CP) $< $|
 
 $(LIBNAME): sgx_tprotected_fs_t.h $(OBJ)
-	$(AR) rcsD $@ $^
+	$(AR) rcsD $@ $(OBJ)
 	
 sgx_tprotected_fs_t.h: $(EDGER8R)
 	$(EDGER8R) --header-only --trusted $(COMMON_DIR)/inc/sgx_tprotected_fs.edl --search-path $(COMMON_DIR)/inc

--- a/sdk/protected_fs/sgx_uprotected_fs/Makefile
+++ b/sdk/protected_fs/sgx_uprotected_fs/Makefile
@@ -50,7 +50,7 @@ all: $(LIBNAME) | $(BUILD_DIR)
 	$(CP) $< $|
 
 $(LIBNAME): sgx_tprotected_fs_u.h $(OBJ)
-	$(AR) rcsD $@ $^
+	$(AR) rcsD $@ $(OBJ)
 	
 sgx_tprotected_fs_u.h: $(EDGER8R)
 	$(EDGER8R) --header-only --untrusted $(COMMON_DIR)/inc/sgx_tprotected_fs.edl --search-path $(COMMON_DIR)/inc


### PR DESCRIPTION
The new `protected_fs` library is shipped within two static libraries (libsgx_tprotected_fs.a and libsgx_uprotected_fs.a). Both of them include a header file. These two header files would cause linking problem because in many circumstances, these two header files appear in source code directories and source codes include them. This patch is intended to resolve this conflict.

Signed-off-by: Yu Ding <dingyu02@baidu.com>