### PR TITLE
Mention environment set up to compile samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ To install the Intel(R) SGX SDK, invoke the installer, as follows:
 $ cd linux/installer/bin
 $ ./sgx_linux_x64_sdk_${version}.bin 
 ```
+NOTE: You need to set up the needed environment variables before compiling your code. To do so, run:
+```
+   $ source ${sgx-sdk-install-path}/environment
+```
 ### Test the Intel(R) SGX SDK Package with the Code Samples
 - Compile and run each code sample in Simulation mode to make sure the package works well:    
 ```
@@ -150,6 +154,7 @@ $ ./sgx_linux_x64_sdk_${version}.bin
   $ ./app
 ```
    Use similar commands for other sample codes.
+
 ### Compile and Run the Code Samples in the Hardware Mode
 If you use an Intel SGX hardware enabled machine, you can run the code samples in Hardware mode.
 Ensure that you install Intel(R) SGX driver and Intel(R) SGX PSW installer on the machine.  
@@ -161,8 +166,7 @@ See the later topic, *Install Intel(R) SGX PSW*, for information on how to insta
   $ make
   $ ./app
 ```
-   Use similar commands for other code samples.   
-
+   Use similar commands for other code samples.
 
 Install the Intel(R) SGX PSW
 ------------------------

--- a/SampleCode/Cxx11SGXDemo/README.txt
+++ b/SampleCode/Cxx11SGXDemo/README.txt
@@ -26,7 +26,9 @@ The project demonstrates serveral C++11 features inside the Enclave:
 How to Build/Execute the C++11 sample program
 ---------------------------------------------
 1. Install Intel(R) Software Guard Extensions (Intel(R) SGX) SDK for Linux* OS
-2. Build the project with the prepared Makefile:
+2. Make sure your environment is set:
+    $ source ${sgx-sdk-install-path}/environment
+3. Build the project with the prepared Makefile:
     a. Hardware Mode, Debug build:
         $ make
     b. Hardware Mode, Pre-release build:
@@ -39,6 +41,6 @@ How to Build/Execute the C++11 sample program
         $ make SGX_MODE=SIM SGX_PRERELEASE=1 SGX_DEBUG=0
     f. Simulation Mode, Release build:
         $ make SGX_MODE=SIM SGX_DEBUG=0
-3. Execute the binary directly:
+4. Execute the binary directly:
     $ ./app
-4. Remember to "make clean" before switching build mode
+5. Remember to "make clean" before switching build mode

--- a/SampleCode/LocalAttestation/README.txt
+++ b/SampleCode/LocalAttestation/README.txt
@@ -9,7 +9,9 @@ The project demonstrates:
 How to Build/Execute the Sample Code
 ------------------------------------
 1. Install Intel(R) Software Guard Extensions (Intel(R) SGX) SDK for Linux* OS
-2. Build the project with the prepared Makefile:
+2. Make sure your environment is set:
+    $ source ${sgx-sdk-install-path}/environment
+3. Build the project with the prepared Makefile:
     a. Hardware Mode, Debug build:
         $ make
     b. Hardware Mode, Pre-release build:
@@ -22,6 +24,6 @@ How to Build/Execute the Sample Code
         $ make SGX_MODE=SIM SGX_PRERELEASE=1 SGX_DEBUG=0
     f. Simulation Mode, Release build:
         $ make SGX_MODE=SIM SGX_DEBUG=0
-3. Execute the binary directly:
+4. Execute the binary directly:
     $ ./app
-4. Remember to "make clean" before switching build mode
+5. Remember to "make clean" before switching build mode

--- a/SampleCode/PowerTransition/README.txt
+++ b/SampleCode/PowerTransition/README.txt
@@ -8,7 +8,9 @@ Software Guard Extensions projects development.
 How to Build/Execute the Sample Code
 ------------------------------------
 1. Install Intel(R) Software Guard Extensions (Intel(R) SGX) SDK for Linux* OS
-2. Build the project with the prepared Makefile:
+2. Make sure your environment is set:
+    $ source ${sgx-sdk-install-path}/environment
+3. Build the project with the prepared Makefile:
     a. Hardware Mode, Debug build:
         $ make
     b. Hardware Mode, Pre-release build:
@@ -21,6 +23,6 @@ How to Build/Execute the Sample Code
         $ make SGX_MODE=SIM SGX_PRERELEASE=1 SGX_DEBUG=0
     f. Simulation Mode, Release build:
         $ make SGX_MODE=SIM SGX_DEBUG=0
-3. Execute the binary directly:
+4. Execute the binary directly:
     $ ./app
-4. Remember to "make clean" before switching build mode
+5. Remember to "make clean" before switching build mode

--- a/SampleCode/RemoteAttestation/README.txt
+++ b/SampleCode/RemoteAttestation/README.txt
@@ -9,7 +9,9 @@ The project demonstrates:
 How to Build/Execute the Sample Code
 ------------------------------------
 1. Install Intel(R) Software Guard Extensions (Intel(R) SGX) SDK for Linux* OS
-2. Build the project with the prepared Makefile:
+2. Make sure your environment is set:
+    $ source ${sgx-sdk-install-path}/environment
+3. Build the project with the prepared Makefile:
     a. Hardware Mode, Debug build:
         $ make
     b. Hardware Mode, Pre-release build:
@@ -22,6 +24,6 @@ How to Build/Execute the Sample Code
         $ make SGX_MODE=SIM SGX_PRERELEASE=1 SGX_DEBUG=0
     f. Simulation Mode, Release build:
         $ make SGX_MODE=SIM SGX_DEBUG=0
-3. Execute the binary directly:
+4. Execute the binary directly:
     $ ./app
-4. Remember to "make clean" before switching build mode
+5. Remember to "make clean" before switching build mode

--- a/SampleCode/SampleEnclave/README.txt
+++ b/SampleCode/SampleEnclave/README.txt
@@ -11,7 +11,9 @@ Extensions (Intel(R) SGX) SDK:
 How to Build/Execute the Sample Code
 ------------------------------------
 1. Install Intel(R) SGX SDK for Linux* OS
-2. Build the project with the prepared Makefile:
+2. Make sure your environment is set:
+    $ source ${sgx-sdk-install-path}/environment
+3. Build the project with the prepared Makefile:
     a. Hardware Mode, Debug build:
         $ make
     b. Hardware Mode, Pre-release build:
@@ -24,7 +26,7 @@ How to Build/Execute the Sample Code
         $ make SGX_MODE=SIM SGX_PRERELEASE=1 SGX_DEBUG=0
     f. Simulation Mode, Release build:
         $ make SGX_MODE=SIM SGX_DEBUG=0
-3. Execute the binary directly:
+4. Execute the binary directly:
     $ ./app
-4. Remember to "make clean" before switching build mode
+5. Remember to "make clean" before switching build mode
 

--- a/SampleCode/SealedData/README.txt
+++ b/SampleCode/SealedData/README.txt
@@ -11,7 +11,9 @@ replay-protected policy, and Trusted Time to enforce time based policy
 How to Build/Execute the Sample Code
 ------------------------------------
 1. Install Intel(R) Software Guard Extensions (Intel(R) SGX) SDK for Linux* OS
-2. Build the project with the prepared Makefile:
+2. Make sure your environment is set:
+    $ source ${sgx-sdk-install-path}/environment
+3. Build the project with the prepared Makefile:
     a. Hardware Mode, Debug build:
         $ make
     b. Hardware Mode, Pre-release build:
@@ -24,6 +26,6 @@ How to Build/Execute the Sample Code
         $ make SGX_MODE=SIM SGX_PRERELEASE=1 SGX_DEBUG=0
     f. Simulation Mode, Release build:
         $ make SGX_MODE=SIM SGX_DEBUG=0
-3. Execute the binary directly:
+4. Execute the binary directly:
     $ ./app
-4. Remember to "make clean" before switching build mode
+5. Remember to "make clean" before switching build mode


### PR DESCRIPTION
In some cases, it may be necessary to source the needed environment
variables before compiling the sample codes. Mention it in the main
README and also in every sample code README.

Even if the installer tells the user to source these vars, it's an easy thing to miss
and I think it should be mentioned in the repo documentation.

Signed-off-by: Clenimar Filemon <clenimar.filemon@gmail.com>