### PR TITLE
Fix linker error due to undefined reference.

### DIFF
--- a/sdk/libcapable/linux/sgx_capable.cpp
+++ b/sdk/libcapable/linux/sgx_capable.cpp
@@ -39,7 +39,7 @@
 #include <sgx_capable.h>
 
 #include "se_cdefs.h"
-SGX_ACCESS_VERSION(sgx_capable, 1);
+SGX_ACCESS_VERSION(capable, 1);
 
 /* __cpuid(unsinged int info[4], unsigned int leaf, unsigned int subleaf); */
 /* Because gcc's __get_cpuid() intrinsic is difficult to work with */


### PR DESCRIPTION
* Calling the macro "SGX_ACCESS_VERSION(sgx_capable, 1)" results in a
  reference to "sgx_sgx_capable_version" which is undefined. The correct
  reference is "sgx_capable_version".

Signed-off-by: Reimo Rebane <reimo.rebane@cyber.ee>