### PR TITLE
Fix bug in aesm_service and uae_service shared code

### DIFF
--- a/psw/ae/common/src/AEGetWhiteListRequest.cpp
+++ b/psw/ae/common/src/AEGetWhiteListRequest.cpp
@@ -49,6 +49,7 @@ AEGetWhiteListRequest::AEGetWhiteListRequest(uint32_t whiteListSize, uint32_t ti
     :m_request(NULL)
 
 {
+    m_request = new aesm::message::Request::GetWhiteListRequest();
     m_request->set_white_list_size(whiteListSize);
     m_request->set_timeout(timeout);
 }

--- a/psw/ae/common/src/AEGetWhiteListSizeRequest.cpp
+++ b/psw/ae/common/src/AEGetWhiteListSizeRequest.cpp
@@ -46,6 +46,7 @@ AEGetWhiteListSizeRequest::AEGetWhiteListSizeRequest(const aesm::message::Reques
 AEGetWhiteListSizeRequest::AEGetWhiteListSizeRequest(uint32_t timeout)
     :m_request(NULL)
 {
+    m_request = new aesm::message::Request::GetWhiteListSizeRequest();
     m_request->set_timeout(timeout);
 }
 


### PR DESCRIPTION
Object is not allocated before dereferencing pointer.

Signed-off-by: Li, Xun <xun.li@intel.com>